### PR TITLE
Upgrades dependencies, defines gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Maven
+*target

--- a/pom.xml
+++ b/pom.xml
@@ -7,23 +7,22 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.1</version>
+        <version>3.0.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <groupId>me.creighton</groupId>
     <artifactId>brevis</artifactId>
-    <version>1.0</version>
+    <version>1.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>17</jdk.version>
-        <spring-boot-maven-plugin-version>2.6.1</spring-boot-maven-plugin-version>
-        <maven-surefire-version>3.0.0-M7</maven-surefire-version>
-        <maven-compiler-plugin-version>3.10.1</maven-compiler-plugin-version>
-        <maven-jar-plugin-version>3.2.2</maven-jar-plugin-version>
-        <junit-bom-version>5.9.0</junit-bom-version>
+        <maven-surefire.version>3.1.0</maven-surefire.version>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+        <junit-bom.version>5.9.3</junit-bom.version>
     </properties>
     <dependencies>
             <!-- https://mvnrepository.com/artifact/org.junit/junit-bom -->
@@ -42,7 +41,7 @@
         <dependency>
             <groupId>org.junit</groupId>
             <artifactId>junit-bom</artifactId>
-            <version>${junit-bom-version}</version>
+            <version>${junit-bom.version}</version>
             <type>pom</type>
         </dependency>
 
@@ -60,12 +59,12 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven-surefire-version}</version>
+                    <version>${maven-surefire.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${maven-compiler-plugin-version}</version>
+                    <version>${maven-compiler-plugin.version}</version>
                     <configuration>
                         <source>${jdk.version}</source>
                         <target>${jdk.version}</target>
@@ -74,7 +73,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>${maven-jar-plugin-version}</version>
+                    <version>${maven-jar-plugin.version}</version>
                     <configuration>
                         <archive>
                             <manifest>


### PR DESCRIPTION
Upgrades these dependencies:
- Spring Boot from 2.7.1 to 3.0.6
- maven-surefire-version from 3.0.0-M7 to 3.1.0
- maven-compiler-plugin-version from 3.10 3.11.0
- maven-jar-plugin-version from 3.2 to 3.3.0
- junit-bom-version from 5.9.0 to 5.9.3

Renames version properties to use a ".version" suffix rather than "-version" to conform to Spring Boot's convention.

Stops defining spring-boot-maven-plugin-version as it wasn't used. Also, it's best to let the version of that plugin be managed by Spring Boot.

Adds a .gitignore to prevent Maven's target directory from being version controlled.

Switches version to use SNAPSHOT to better represent work in progress.